### PR TITLE
Make A Status Code Response Of 2XX Equal Success

### DIFF
--- a/bin/enqueue_notify_task
+++ b/bin/enqueue_notify_task
@@ -44,10 +44,10 @@ HTTP_STATUS="\$(curl --connect-timeout 1 -s -S "${NOTIFY_URL}" -H 'Content-Type:
 SEND_RESULT=\$?
 # output the result of our curl, regardless of the result
 cat \${CURL_OUTPUT_FILE}
-if [ \${SEND_RESULT} -ne 0  -o \${HTTP_STATUS} -ne 200 ]; then
+if [ \${SEND_RESULT} -ne 0 -o \${HTTP_STATUS} -lt 200 -o \${HTTP_STATUS} -ge 300 ]; then
   if [ -n "${PUSH_ERROR_NOTIFY_URL}" ]; then
     if printf "${MESSAGE_SOURCE}" | grep -E 'bottle\/push\/error'; then
-      # if the message we failed to push is the message indicating a failure to push, we 
+      # if the message we failed to push is the message indicating a failure to push, we
       # MUST NOT SEND IT, lest we DoS ourselves
       :
     else


### PR DESCRIPTION
Accept response status code >= 200 and < 300 as success, in other words 2XX = success.